### PR TITLE
Missing QT includes

### DIFF
--- a/bitcoin-qt.pro
+++ b/bitcoin-qt.pro
@@ -5,6 +5,10 @@ INCLUDEPATH += src src/json src/qt
 DEFINES += QT_GUI BOOST_THREAD_USE_LIB BOOST_SPIRIT_THREADSAFE
 CONFIG += no_include_pwd
 
+CONFIG += qt
+QT += gui
+QT += widgets
+
 # for boost 1.37, add -mt to the boost libraries 
 # use: qmake BOOST_LIB_SUFFIX=-mt
 # for boost thread win32 with _win32 sufix


### PR DESCRIPTION
Using Qt4 on Lubuntu 16.10 I needed these additional lines to qmake and make Manna-Qt